### PR TITLE
Added some new sio metrics =)

### DIFF
--- a/cfg/metric_definition.json
+++ b/cfg/metric_definition.json
@@ -243,5 +243,25 @@
     "type": "gauge",
     "help": "Help Text",
     "name": "fixed_read_error"
+  },
+  "BackgroundScannedInMB": {
+    "type": "gauge",
+    "help": "Help Text",
+    "name": "background_scan_mb"
+  },
+  "userDataSdcReadLatency": {
+    "type": "gauge",
+    "help": "Help Text",
+    "name": "sdc_read_latency"
+  },
+  "userDataSdcWriteLatency": {
+    "type": "gauge",
+    "help": "Help Text",
+    "name": "sdc_write_latency"
+  },
+  "userDataSdcTrimLatency": {
+    "type": "gauge",
+    "help": "Help Text",
+    "name": "sdc_trim_latency"
   }
 }

--- a/cfg/metric_query_selection.json
+++ b/cfg/metric_query_selection.json
@@ -73,7 +73,10 @@
         "numOfChildVolumes",
         "numOfDescendantVolumes",
         "userDataReadBwc",
-        "userDataWriteBwc"
+        "userDataWriteBwc",
+        "userDataSdcReadLatency",
+        "userDataSdcWriteLatency",
+        "userDataSdcTrimLatency"
       ]
     },
     {
@@ -118,7 +121,9 @@
         "avgReadSizeInBytes",
         "avgWriteSizeInBytes",
         "totalReadBwc",
-        "totalWriteBwc"
+        "totalWriteBwc",
+        "fixedReadErrorCount",
+        "BackgroundScannedInMB"
       ]
     },
     {


### PR DESCRIPTION
- Fixed : This metrics fixedReadErrorCount was present in metric_definition.json but not in metric_query_selection.json
- Added in class Volume : userDataSdcReadLatency & userDataSdcWriteLatency & userDataSdcTrimLatency
- Added in class Device : BackgroundScannedInMB (check this one before merging to be sure it is a gauge)
